### PR TITLE
Add ability to delete all redbird sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ plug Plug.Session,
   expiration_in_seconds: 3000 # Optional - default is 30 days
 ```
 
+### Configure Redbird
+
+All redbird created keys are automatically namespaced with `redbird_session` by
+default. If you'd like to set your own custom, per app, configuration you can
+set that in the config.
+
+```elixir
+config :redbird, key_namespace: "my_app_"
+```
+
+## Mix tasks
+
+This will give you access to the mix task `mix redbird.delete_all_sessions`, for
+clearing all Redbird created user sessions from Redis. If you have not set up a
+per app `key_namespace` in the config this will clear ALL Redbird sessions on
+your server. Otherwise it will only clear the sessions created by the specific
+app you're running it in.
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/mix/tasks/redbird/delete_all_sessions.ex
+++ b/lib/mix/tasks/redbird/delete_all_sessions.ex
@@ -1,0 +1,22 @@
+defmodule Mix.Tasks.Redbird.DeleteAllSessions do
+  use Mix.Task
+
+  @shortdoc "Deletes all redbird sessions"
+
+  @moduledoc """
+  Deletes all redbird sessions.
+      mix redbird.delete_all_sessions my_app
+  The first argument is the app specific key_namespace you set in your plug
+  session config. If no argument is given, it will delete all redbird sessions.
+  """
+  def run(_args) do
+    Redbird.start(nil, nil)
+    Plug.Session.REDIS.namespace
+    |> delete_all_sessions
+  end
+
+  def delete_all_sessions(namespace) do
+    Redbird.Redis.keys("#{namespace}*")
+    |> Redbird.Redis.del
+  end
+end

--- a/lib/redbird/plug/session/redis.ex
+++ b/lib/redbird/plug/session/redis.ex
@@ -14,10 +14,10 @@ defmodule Plug.Session.REDIS do
     opts
   end
 
-  def get(_conn, redis_key, _init_options) do
-    case get(redis_key) do
+  def get(_conn, namespaced_key, _init_options) do
+    case get(namespaced_key) do
       :undefined -> {nil, %{}}
-      value -> {redis_key, value |> :erlang.binary_to_term}
+      value -> {namespaced_key, value |> :erlang.binary_to_term}
     end
   end
 
@@ -25,13 +25,30 @@ defmodule Plug.Session.REDIS do
     put(conn, generate_random_key(), data, init_options)
   end
   def put(_conn, redis_key, data, init_options) do
-    setex(%{key: redis_key, value: data, seconds: session_expiration(init_options)})
-    redis_key
+    key = add_namespace(redis_key)
+    setex(%{
+      key: key,
+      value: data,
+      seconds: session_expiration(init_options)
+    })
+    key
   end
 
   def delete(_conn, redis_key, _kinit_options) do
     del(redis_key)
     :ok
+  end
+
+  defp add_namespace(key) do
+    namespace <> key
+  end
+
+  def namespace do
+    Application.get_env(:redbird, :key_namespace, redbird_namespace)
+  end
+
+  def redbird_namespace do
+    "redbird_session_"
   end
 
   defp generate_random_key do

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -17,6 +17,10 @@ defmodule Redbird.Redis do
     Exredis.Api.del(pid(), key)
   end
 
+  def keys(pattern) do
+    Exredis.Api.keys(pattern)
+  end
+
   def pid do
     :redbird_phoenix_session
   end

--- a/test/mix/tasks/redbird/delete_all_sessions_test.exs
+++ b/test/mix/tasks/redbird/delete_all_sessions_test.exs
@@ -1,0 +1,31 @@
+defmodule Mix.Tasks.Redbird.DeleteAllSessionsTest do
+  use ExUnit.Case
+  alias Plug.Session.REDIS
+
+  setup do
+    on_exit fn ->
+      Mix.Tasks.Redbird.DeleteAllSessions.run([])
+    end
+  end
+
+  test "deletes all redbird session keys" do
+    key = "redis_session"
+    conn = %{}
+    options = []
+    REDIS.put(conn, key, %{foo: :bar}, options)
+
+    assert {nil, %{}} = REDIS.get(conn, key, options)
+  end
+
+  test "deletes user defined namespaced session keys" do
+    Application.put_env(:redbird, :key_namespace, "test_")
+    conn = %{}
+    key = "redis_session"
+    options = []
+    REDIS.put(conn, key, %{foo: :bar}, options)
+
+    Mix.Tasks.Redbird.DeleteAllSessions.run([])
+
+    assert {nil, %{}} = REDIS.get(conn, "test_" <> key, options)
+  end
+end


### PR DESCRIPTION
* Prepends all session keys with "redbird_sessions_" so that it will be
easy to identify which keys in the users redis database were set through
Redbird

* Adds the ExRedis `keys` option to find all keys that start with the
redbird session

* Adds `delete_all_sessions` to delete all matching keys