### PR TITLE
Remove applications method set up from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@ It works great for Phoenix!
 
 ## Installation
 
-### Add Redbird to your application and dependency list.
+### Add Redbird to your dependency list.
 
 ```elixir
-  def applications do
-    [
-      :redbird,
-    ]
-  end
-
   def deps do
     [
       {:redbird, "~> 0.4.0"},


### PR DESCRIPTION
Hey, just a minor update to the README.

You no longer need to explicitly add `redbird` to applications, as mix handles that automatically through [application inference](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference).