### PR TITLE
Update to Elixir 1.7 & update CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.6.4
+      - image: circleci/elixir:1.7.4
       - image: redis:2.8.6
     working_directory: /home/circleci/redbird
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,51 @@ jobs:
   build:
     docker:
       - image: circleci/elixir:1.7.4
-      - image: redis:2.8.6
+        environment:
+          MIX_ENV: test
+      - image: redis:6.0.7
     working_directory: /home/circleci/redbird
     steps:
       - checkout
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
       - restore_cache:
           keys:
-          - dependency-cache-{{ arch }}-{{ .Branch }}-{{ checksum "mix.lock" }}
-          - dependency-cache-{{ arch }}-{{ .Branch }}
-          - dependency-cache-{{ arch }}
-      - run: mix local.hex --force && mix local.rebar --force && mix deps.get
+            - v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v1-mix-cache-{{ .Branch }}
+            - v1-mix-cache
+      - restore_cache:
+          keys:
+            - v1-build-cache-{{ .Branch }}-{{ checksum ".tool-versions" }}
+            - v1-build-cache-{{ .Branch }}
+            - v1-build-cache
+      - run: mix do deps.get, compile --warnings-as-errors
       - save_cache:
-          key: dependency-cache-{{ arch }}-{{ .Branch }}-{{ checksum "mix.lock" }}
+          key: v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: "deps"
       - save_cache:
-          key: dependency-cache-{{ arch }}-{{ .Branch }}
+          key: v1-mix-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
-          key: dependency-cache-{{ arch }}
+          key: v1-mix-cache
           paths: "deps"
-      - run: bin/test_suite
+      - save_cache:
+          key: v1-build-cache-{{ .Branch }}-{{ checksum ".tool-versions" }}
+          paths: "_build"
+      - save_cache:
+          key: v1-build-cache-{{ .Branch }}
+          paths: "_build"
+      - save_cache:
+          key: v1-build-cache
+          paths: "_build"
+
+      - run:
+          name: Wait for Redis
+          command: dockerize -wait tcp://localhost:6379 -timeout 1m
+
+      - run: mix test
 experimental:
   notify:
     branches:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 20.3
-elixir 1.6.4
+elixir 1.7.4-otp-20

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Redbird.Mixfile do
       app: :redbird,
       build_embedded: Mix.env() == :prod,
       deps: deps(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       version: "0.4.0",
       package: [
@@ -22,7 +22,7 @@ defmodule Redbird.Mixfile do
 
   def application do
     [
-      applications: [:logger],
+      extra_applications: [:logger],
       mod: {Redbird, []}
     ]
   end


### PR DESCRIPTION
We update the app to use Elixir 1.7. With Elixir 1.11 out, 1.7 is becoming the oldest version many libraries support.

This change will also be helpful in a future change to use Redix as the redis library that will require Elixir 1.7.

We also update the CircleCI's config since it was tough to run the tests. We make the following changes:

- Use newer version of Redis (version 2 is fairly old)
- Use MIX_ENV=test since we're in CI.
- Cache deps and build (previously we cached the deps). We also have a hardcoded v1 cache-key so we can bust the cache manually if we need that by incrementing the version.
- Since we cache the build and deps, we do a `mix compile` earlier in the process and no longer need to run `bin/test_suite` (which compiled and ran tests). We just run `mix test` at the end.
- We add CircleCI's suggested wait for command to ensure Redis is available before we run our tests.