### PR TITLE
Add bin/release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+previous_version="${1}"
+release_version="${2}"
+
+sed -i '' "s/$previous_version/$release_version/" README.md
+sed -i '' "s/$previous_version/$release_version/" mix.exs
+
+git commit -m "Release version $release_version"
+git tag "v$release_version"
+git push origin "v$release_version"
+mix hex.publish


### PR DESCRIPTION
Adds a simple bin/release script that will change the version referenced
in the README and in `mix.exs` from the previous version to the new
version.

It then commits the release, creates a tag, and pushes to github.
Finally it runs `mix hex.publish` to publish the package.

Example usage:

```
bin/release 0.4.0 0.5.0
```