### PR TITLE
Allow setting URL for redis config

### DIFF
--- a/lib/redbird.ex
+++ b/lib/redbird.ex
@@ -2,10 +2,10 @@ defmodule Redbird do
   use Application
 
   def start(_type, _args) do
-    redis_options = Application.get_env(:redbird, :redis_options, [])
+    redis_options = Redbird.Config.redis_options(name: Redbird.Redis.pid())
 
     children = [
-      {Redbird.Redis, [{:name, Redbird.Redis.pid()} | redis_options]}
+      {Redix, redis_options}
     ]
 
     opts = [strategy: :one_for_one, name: Redbird.Supervisor]

--- a/lib/redbird/config.ex
+++ b/lib/redbird/config.ex
@@ -1,0 +1,17 @@
+defmodule Redbird.Config do
+  def redis_options(options \\ []) do
+    redis_opts = Keyword.merge(options, application_config_options())
+    url = redis_opts[:url]
+    opts = Keyword.delete(redis_opts, :url)
+
+    if url do
+      {url, opts}
+    else
+      opts
+    end
+  end
+
+  defp application_config_options do
+    Application.get_env(:redbird, :redis_options, [])
+  end
+end

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -1,15 +1,4 @@
 defmodule Redbird.Redis do
-  def child_spec(args) do
-    %{
-      id: Redbird.Redis,
-      start: {Redbird.Redis, :start_link, [args]}
-    }
-  end
-
-  def start_link(opts) do
-    Redix.start_link(opts)
-  end
-
   def get(key) do
     pid()
     |> Redix.command!(["GET", key])

--- a/test/redbird/config_test.exs
+++ b/test/redbird/config_test.exs
@@ -1,0 +1,39 @@
+defmodule Redbird.ConfigTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    on_exit(fn ->
+      Application.put_env(:redbird, :redis_options, [])
+    end)
+  end
+
+  describe "redis_options" do
+    test "returns an empty list by default" do
+      assert [] == Redbird.Config.redis_options()
+    end
+
+    test "returns application config's redis_options" do
+      Application.put_env(:redbird, :redis_options, host: "localhost")
+
+      redis_options = Redbird.Config.redis_options()
+
+      assert [host: "localhost"] == redis_options
+    end
+
+    test "returns url tuple if url is present" do
+      options = [url: "rediss://localhost:3400", host: "localhost"]
+      Application.put_env(:redbird, :redis_options, options)
+
+      {url, opts} = Redbird.Config.redis_options()
+
+      assert url == options[:url]
+      assert opts == [host: "localhost"]
+    end
+
+    test "allows options to be passed" do
+      redis_options = Redbird.Config.redis_options(name: :redis)
+
+      assert [name: :redis] == redis_options
+    end
+  end
+end


### PR DESCRIPTION
What changed?
=============

We allow setting a Redis URL in our config via `redis_options` instead of having to specify a host, port, and password.

E.g.

```
// instead of this
config :redbird, :redis_options, [host: ...]

// we can now do this
config :redbird, :redis_options, [url: "redis:// ..."]
```

This is particularly helpful when dealing with Redis + SSL, when the URL scheme changes from `redis` to `rediss`.

Implementation details
----------------------

`Redix` (the library we use to communicate with Redis) will automatically set `ssl: true` when it is passed a URL with a `rediss` scheme.

Unfortunately, the only way to pass a URL to `Redix` is by passing a modified set of options (`{url, list_of_opts}` instead of `list_of_opts`).

Instead of passing those options to `Redbird.Redis.start_link/1` only to then pass them again to `Redix.start_link/1`, we now rely on `Redix`'s `child_spec` function directly, and put it in our supervision tree.

Finally, to abstract the configuration of options, we create a new module `Redbird.Config` which handles the merging of options and separating the `url` from the rest of the options if one is present.