### PR TITLE
Avoid resetting the session key with each call to put/4

### DIFF
--- a/lib/redbird/key.ex
+++ b/lib/redbird/key.ex
@@ -15,7 +15,7 @@ defmodule Redbird.Key do
     Crypto.verify_key(key, conn)
   end
 
-  def deletable?(key, conn) do
+  def accessible?(key, conn) do
     with {:ok, key, _} <- extract_key(key),
          {:ok, _verified_key} <- Crypto.verify_key(key, conn) do
       true

--- a/lib/redbird/key.ex
+++ b/lib/redbird/key.ex
@@ -11,13 +11,9 @@ defmodule Redbird.Key do
     to_string(namespace) <> Crypto.sign_key(key, conn)
   end
 
-  def verify(key, conn) do
-    Crypto.verify_key(key, conn)
-  end
-
-  def accessible?(key, conn) do
+  def accessible?(key, conn, opts \\ []) do
     with {:ok, key, _} <- extract_key(key),
-         {:ok, _verified_key} <- Crypto.verify_key(key, conn) do
+         {:ok, _verified_key} <- Crypto.verify_key(key, conn, opts) do
       true
     else
       _ -> false

--- a/lib/redbird/plug/session/redis.ex
+++ b/lib/redbird/plug/session/redis.ex
@@ -40,7 +40,7 @@ defmodule Plug.Session.REDIS do
       key
       |> set_key_with_retries(Value.serialize(data), max_age, 1)
     else
-      key
+      put(conn, nil, data, init_options)
     end
   end
 

--- a/test/redbird/key_test.exs
+++ b/test/redbird/key_test.exs
@@ -102,34 +102,34 @@ defmodule Redbird.KeyTest do
     end
   end
 
-  describe "deletable?/2" do
-    test "verifiable keys with a namespace are deletable" do
+  describe "accessible?/2" do
+    test "verifiable keys with a namespace are accessible" do
       conn = Redbird.ConnCase.signed_conn()
       generated_key = Key.generate(Key.namespace())
       signed_key = Key.sign_key(generated_key, conn)
 
-      actual = Key.deletable?(signed_key, conn)
+      actual = Key.accessible?(signed_key, conn)
 
       assert actual == true
     end
 
-    test "verifiable keys without a namespace are deletable" do
+    test "verifiable keys without a namespace are accessible" do
       conn = Redbird.ConnCase.signed_conn()
       generated_key = Key.generate("")
       signed_key = Key.sign_key(generated_key, conn)
 
-      actual = Key.deletable?(signed_key, conn)
+      actual = Key.accessible?(signed_key, conn)
 
       assert actual == true
     end
 
-    test "non-verifiable keys are not-deletable" do
+    test "non-verifiable keys are not-accessible" do
       conn = Redbird.ConnCase.signed_conn()
       generated_key = Key.generate("")
       signed_key = Key.sign_key(generated_key, conn)
       tampered_key = signed_key <> "sneaky"
 
-      actual = Key.deletable?(tampered_key, conn)
+      actual = Key.accessible?(tampered_key, conn)
 
       assert actual == false
     end

--- a/test/redbird_test.exs
+++ b/test/redbird_test.exs
@@ -57,6 +57,29 @@ defmodule RedbirdTest do
       assert get_session(conn, :foo) == "bar"
     end
 
+    test "it reuses the session key between requests" do
+      secret = generate_secret()
+
+      conn =
+        :get
+        |> conn("/")
+        |> sign_conn_with(secret)
+        |> put_session(:foo, "bar")
+        |> send_resp(200, "")
+
+      session_key = conn.resp_cookies["_session_key"].value
+
+      conn =
+        :get
+        |> conn("/")
+        |> recycle_cookies(conn)
+        |> sign_conn_with(secret)
+        |> put_session(:foo, "baz")
+        |> send_resp(200, "")
+
+      assert conn.resp_cookies["_session_key"].value == session_key
+    end
+
     test "it allows configuring session expiration" do
       conn =
         :get


### PR DESCRIPTION
After upgrading to the new v0.7.0 of redbird, I found I consistently got `Plug.Conn.CookieOverflowError`s after a few requests.

This is strange—the session key is supposed to be stable, yet it was changing and growing in size with each request.

When I examined the overly-large value being set in the cookie, I saw that it was something signed with `Plug.Crypto.sign`, whose payload is a value _also_ signed by `Plug.Crypto.sign`, and so forth, quite a few levels deep.

In other words: The redis key gets re-signed by `Redbird.Crypto.sign` with every call to `put/4`—even if that key _was already_ signed, leading to a new (larger) key with each request!

The fix is to sign the key exactly once, right after generating it, then verify that the key is signed properly in `put/4` in the same way as in `get/3` or `delete/2`.
