### PR TITLE
Fix the broken session expiration test

### DIFF
--- a/test/redbird_test.exs
+++ b/test/redbird_test.exs
@@ -58,10 +58,12 @@ defmodule RedbirdTest do
     end
 
     test "it allows configuring session expiration" do
+      secret = generate_secret()
+
       conn =
         :get
         |> conn("/")
-        |> sign_conn(expiration_in_seconds: 1)
+        |> sign_conn_with(secret, expiration_in_seconds: 1)
         |> put_session(:foo, "bar")
         |> send_resp(200, "")
 
@@ -71,7 +73,7 @@ defmodule RedbirdTest do
         :get
         |> conn("/")
         |> recycle_cookies(conn)
-        |> sign_conn()
+        |> sign_conn_with(secret)
         |> send_resp(200, "")
 
       assert conn |> get_session(:foo) |> is_nil


### PR DESCRIPTION
While writing the test for #72, I noticed that the test for session expiration was broken: even if you removed the call to `:timer.sleep(1000)` the test would still pass.

By not reusing the secret between the two requests, the second request couldn't access the session from the first, meaning that even if the session hadn't expired it still wouldn't be accessible.

This PR fixes this test, so that it will fail properly if the session expiration doesn't work.