### PR TITLE
Fail open on Redis connection errors  for better resilience via :on_redis_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ set that in the config.
 config :redbird, key_namespace: "my_app_"
 ```
 
+### Behavior when Redis is unreachable
+
+By default, if a Redis command fails with a connection error, redbird raises —
+which crashes every request that touches a session (a session read or write
+happens on most requests), so a Redis outage takes the whole site down.
+
+Set `on_redis_error: :fail_open` to instead degrade gracefully: a session read
+returns no session and a session write is skipped (and logged), so requests keep
+being served while Redis is down and recover automatically once it is back.
+
+```elixir
+config :redbird, on_redis_error: :fail_open # default: :raise
+```
+
 ### Configure Redix
 
 Redbird uses [Redix] to communicate with Redis. You can pass configuration

--- a/lib/redbird/plug/session/redis.ex
+++ b/lib/redbird/plug/session/redis.ex
@@ -56,10 +56,28 @@ defmodule Plug.Session.REDIS do
 
       response ->
         if counter > 5 do
-          Redbird.RedisError.raise(error: response, key: key)
+          handle_set_failure(key, response)
         else
           set_key_with_retries(key, value, seconds, counter + 1)
         end
+    end
+  end
+
+  # When Redis is unreachable, either fail open (skip persistence, keep serving)
+  # or preserve the historical raise-and-crash behavior, per config.
+  defp handle_set_failure(key, response) do
+    case Redbird.Redis.on_redis_error() do
+      :fail_open ->
+        require Logger
+
+        Logger.warning(
+          "Redbird: failing open on session write for #{inspect(key)}; Redis error: #{inspect(response)}"
+        )
+
+        key
+
+      :raise ->
+        Redbird.RedisError.raise(error: response, key: key)
     end
   end
 
@@ -76,7 +94,7 @@ defmodule Redbird.RedisError do
   @base_message "Redbird was unable to store the session in redis."
 
   def raise(error: error, key: key) do
-    message = "#{@base_message} Redis Error: #{error} key: #{key}"
+    message = "#{@base_message} Redis Error: #{inspect(error)} key: #{key}"
     raise __MODULE__, message
   end
 

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -3,6 +3,21 @@ defmodule Redbird.Redis do
   Redis helper functions for Redbird.
   """
 
+  require Logger
+
+  @doc """
+  Configured behavior when a Redis command fails with a connection error.
+
+    * `:raise` (default) — preserve historical behavior: let the error
+      propagate so the request crashes.
+    * `:fail_open` — treat Redis as unavailable: session reads return no
+      session and writes are skipped, so a Redis outage degrades to
+      "no session" instead of crashing every request that touches a session.
+  """
+  def on_redis_error do
+    Application.get_env(:redbird, :on_redis_error, :raise)
+  end
+
   def child_spec(args) do
     %{
       id: Redbird.Redis,
@@ -15,11 +30,24 @@ defmodule Redbird.Redis do
   end
 
   def get(key) do
-    result = Redix.command!(pid(), ["GET", key])
+    case Redix.command(pid(), ["GET", key]) do
+      {:ok, nil} -> :undefined
+      {:ok, response} -> response
+      {:error, error} -> get_error(key, error)
+    end
+  end
 
-    case result do
-      nil -> :undefined
-      response -> response
+  defp get_error(key, error) do
+    case on_redis_error() do
+      :fail_open ->
+        Logger.warning(
+          "Redbird: failing open on session read for #{inspect(key)}; Redis error: #{inspect(error)}"
+        )
+
+        :undefined
+
+      :raise ->
+        raise error
     end
   end
 

--- a/test/redbird/resilience_test.exs
+++ b/test/redbird/resilience_test.exs
@@ -1,0 +1,58 @@
+defmodule Redbird.ResilienceTest do
+  @moduledoc """
+  Fail-open behaviour: when Redis is unreachable, redbird should degrade to
+  "no session" rather than raising and crashing every session-touching request.
+
+  Gated by `config :redbird, on_redis_error: :fail_open | :raise` (default
+  `:raise`, preserving historical behaviour).
+  """
+  use Redbird.ConnCase
+
+  import Mock
+
+  alias Plug.Session.REDIS
+
+  @conn_error %Redix.ConnectionError{reason: :closed}
+
+  describe "Redbird.Redis.get/1 (read path)" do
+    test "fails open (returns :undefined) on a connection error when :fail_open" do
+      set_error_mode(:fail_open)
+
+      with_mock Redix, command: fn _conn, ["GET", _key] -> {:error, @conn_error} end do
+        assert Redbird.Redis.get("redbird_session_abc") == :undefined
+      end
+    end
+
+    test "re-raises on a connection error when :raise (default)" do
+      with_mock Redix, command: fn _conn, ["GET", _key] -> {:error, @conn_error} end do
+        assert_raise Redix.ConnectionError, fn ->
+          Redbird.Redis.get("redbird_session_abc")
+        end
+      end
+    end
+  end
+
+  describe "session write (put) path" do
+    test "fails open (returns the key, no raise) when writes keep failing and :fail_open" do
+      set_error_mode(:fail_open)
+
+      with_mock Redbird.Redis, [:passthrough], setex: fn _ -> @conn_error end do
+        key = REDIS.put(signed_conn(), nil, %{foo: "bar"}, [])
+        assert is_binary(key)
+      end
+    end
+  end
+
+  describe "Redbird.RedisError.raise/1" do
+    test "raises Redbird.RedisError on a Redix.ConnectionError, not a String.Chars crash" do
+      assert_raise Redbird.RedisError, fn ->
+        Redbird.RedisError.raise(error: @conn_error, key: "redbird_session_abc")
+      end
+    end
+  end
+
+  defp set_error_mode(mode) do
+    Application.put_env(:redbird, :on_redis_error, mode)
+    on_exit(fn -> Application.delete_env(:redbird, :on_redis_error) end)
+  end
+end

--- a/test/redbird_test.exs
+++ b/test/redbird_test.exs
@@ -107,9 +107,9 @@ defmodule RedbirdTest do
     end
 
     test "it throws an exception after multiple attempts to store and fail" do
-      with_mock Redbird.Redis, setex: fn _ -> "FAIL" end do
+      with_mock Redbird.Redis, [:passthrough], setex: fn _ -> "FAIL" end do
         assert_raise Redbird.RedisError,
-                     ~r/Redbird was unable to store the session in redis. Redis Error: FAIL/,
+                     ~r/Redbird was unable to store the session in redis. Redis Error: "FAIL"/,
                      fn ->
                        :get
                        |> conn("/")


### PR DESCRIPTION
## The Problem
Most requests touch the session, which means a Redis read on the way in and a write on the way out. When Redis is unreachable redbird raises instead of degrading, so a brief Redis outage returns a 500 for every such request — in practice, the whole site. Worse, the write path's error reporter built its message by interpolating the %Redix.ConnectionError{} struct with String.Chars, which the struct doesn't implement, so the reporter itself crashed with a Protocol.UndefinedError that hid the real Redis error.

## The Fix
Added `config :redbird, on_redis_error: :fail_open` (default `:raise`, so existing behavior is unchanged). In :fail_open mode a failed session read returns no session and a failed write is skipped and logged, so requests keep being served while Redis is down and recover on their own once it returns. RedisError.raise/1 now inspects the error, so it can no longer crash formatting a non-String.Chars value in either mode.

Covered by test/redbird/resilience_test.exs (read and write, both modes, plus the String.Chars regression); documented in README.